### PR TITLE
Script cleanup and bug fixes

### DIFF
--- a/agf2yml/agf2yml.py
+++ b/agf2yml/agf2yml.py
@@ -18,24 +18,27 @@ agffile = 'input/schottzemax-20150722.agf'
 ymldir = 'output/schott'
 references = '1) <a href=\\"http://refractiveindex.info/download/data/2015/schott-optical-glass-collection-datasheets-july-2015-us.pdf\\">SCHOTT optical glass data sheets 2015-07-22</a><br>2) <a href=\\"http://refractiveindex.info/download/data/2015/schottzemax-20150722.agf\\">SCHOTT Zemax catalog 2015-07-22</a>'
 
-#agffile = 'input/OHARA_151201.agf'
-#ymldir = 'output/ohara'
-#references = '1) <a href=\\"http://refractiveindex.info/download/data/2015/ohara_2015-12-01.pdf\\">OHARA optical glass datasheets 2015-12-01</a><br>2) <a href=\\"http://refractiveindex.info/download/data/2015/OHARA_151201.agf\\">OHARA Zemax catalog 2015-12-01</a>'
+"""
+agffile = 'input/OHARA_151201.agf'
+ymldir = 'output/ohara'
+references = '1) <a href=\\"http://refractiveindex.info/download/data/2015/ohara_2015-12-01.pdf\\">OHARA optical glass datasheets 2015-12-01</a><br>2) <a href=\\"http://refractiveindex.info/download/data/2015/OHARA_151201.agf\\">OHARA Zemax catalog 2015-12-01</a>'
 
-#agffile = 'input/HIKARI.agf'
-#ymldir = 'output/hikari'
-#references = '1) <a href=\\"http://refractiveindex.info/download/data/2015/HIKARI_Catalog.pdf\\">HIKARI optical glass catalog 2015-04-01</a><br>2) <a href=\\"http://refractiveindex.info/download/data/2015/HIKARI.agf\\">HIKARI Zemax catalog</a>'
+agffile = 'input/HIKARI.agf'
+ymldir = 'output/hikari'
+references = '1) <a href=\\"http://refractiveindex.info/download/data/2015/HIKARI_Catalog.pdf\\">HIKARI optical glass catalog 2015-04-01</a><br>2) <a href=\\"http://refractiveindex.info/download/data/2015/HIKARI.agf\\">HIKARI Zemax catalog</a>'
 
-#agffile = 'input/HOYA20150618.agf'
-#ymldir = 'output/hoya'
-#references = '<a href=\\"http://refractiveindex.info/download/data/2015/HOYA20150618.agf\\">HOYA Zemax catalog 2015-06-18</a>'
+agffile = 'input/HOYA20150618.agf'
+ymldir = 'output/hoya'
+references = '<a href=\\"http://refractiveindex.info/download/data/2015/HOYA20150618.agf\\">HOYA Zemax catalog 2015-06-18</a>'
+"""
 
-wl = []
-IT = []
-thickness = []
+class GlassData:
+    wl = None
+    IT = None
+    thickness = None
 
-
-def ClearGlassData():
+    glass_count = 0
+    
     name = ''
     comments = ''
     formula = 0
@@ -62,179 +65,173 @@ def ClearGlassData():
     SR = '-' # Acid resistance: 1(high) - 4(low) and 51-53(very low)
     AR = '-' # Alkali resistance: 1(high) - 4(low)
     PR = '-' # Phosphate resistance: 1(high) - 4(low)
-
-    del wl[:]
-    del IT[:]
-    del thickness[:]
+    def __init__(self):
+        self.wl, self.IT, self.thickness = [],[],[]
 
 
-
-def WriteYML(): 
+def WriteYML(gd): 
     
-    if glass_count == 1:
+    if gd.glass_count == 1:
         if not os.path.exists(ymldir):
+            print "Path %s doesn't exist" % ymldir
             os.mkdir(ymldir)
-        os.chdir(ymldir)
         
-    print(str(glass_count)+': '+name)
-    
+    print('{}: {}'.format(gd.glass_count, gd.name))
+    yml_file_path = os.path.join(ymldir, gd.name)
     try:
-        ymlfile = open(name+'.yml', 'w+', encoding='utf-8')
+        ymlfile = open('{}.yml'.format(yml_file_path), 'w+', encoding='utf-8')
     except TypeError: # Python2 has no encoding= argument
-        ymlfile = open(name+'.yml', 'w+')
+        ymlfile = open('{}.yml'.format(yml_file_path), 'w+')
 
-    ymlfile.write('# this file is part of refractiveindex.info database\n# refractiveindex.info database is in the public domain\n# copyright and related rights waived via CC0 1.0\n\n')
+    ymlfile.write("# this file is part of refractiveindex.info database\n# refractiveindex.info database is in the public domain\n# copyright and related rights waived via CC0 1.0\n\n")
     ymlfile.write('REFERENCES: "' + references + '"\n')
     
-    if comments:
-        ymlfile.write('COMMENTS: "' + ' '.join(comments) + '"\n')
+    if gd.comments:
+        ymlfile.write('COMMENTS: "' + ' '.join(gd.comments) + '"\n')
     
     ymlfile.write('DATA:\n')
 
-    if formula == "1" or formula == "13":
+    if gd.formula == "1" or gd.formula == "13":
         ymlfile.write('  - type: formula 3 \n')
-    if formula == "2":
+    if gd.formula == "2":
         ymlfile.write('  - type: formula 2 \n')
-    ymlfile.write('    range: {} {}\n'.format(wlmin, wlmax))
+    ymlfile.write('    range: {} {}\n'.format(float(gd.wlmin), float(gd.wlmax)))
     ymlfile.write('    coefficients:')
-    if formula == "1" or formula == "13":
+    if gd.formula == "1" or gd.formula == "13":
         for i, k in zip(range(8), ['', 2, 4, -2, -6, -8, -10, -12]):
-            if float(disp_formula_coefficients[i]):
-                ymlfile.write(' {} {}'.format(disp_formula_coefficients[i], k))
-    if formula == "2":
+            if float(gd.disp_formula_coefficients[i]):
+                ymlfile.write(' {} {}'.format(gd.disp_formula_coefficients[i], k))
+    if gd.formula == "2":
         ymlfile.write(' 0')
-        num_coeff = len(disp_formula_coefficients) 
+        num_coeff = len(gd.disp_formula_coefficients) 
         for i in range(0, 16, 2):
-            if num_coeff > i+1 and float(disp_formula_coefficients[i]):
-                ymlfile.write(' {} {}'.format(disp_formula_coefficients[i],
-                                              disp_formula_coefficients[i+1]))
+            if num_coeff > i+1 and float(gd.disp_formula_coefficients[i]):
+                ymlfile.write(' {} {}'.format(float(gd.disp_formula_coefficients[i]),
+                                              float(gd.disp_formula_coefficients[i+1])))
     ymlfile.write('\n')
     
     ymlfile.write('  - type: tabulated k\n')
     ymlfile.write('    data: |\n')  
-    for i in range (0,len(wl)):
-        if float(IT[i]) != 0:
-            k = -float(wl[i]) / (4*math.pi) * \
-                math.log(float(IT[i])) / (float(thickness[i])*1000)
-            ymlfile.write('        {:.3f} {:.4E}\n'.format(float(wl[i]), k))
+    for i in range (0, len(gd.wl)):
+        if float(gd.IT[i]) != 0:
+            k = -float(gd.wl[i]) / (4*math.pi) * \
+                math.log(float(gd.IT[i])) / (float(gd.thickness[i])*1000)
+            ymlfile.write('        {:.3f} {:.4E}\n'.format(float(gd.wl[i]), k))
     
     ymlfile.write('INFO:\n')
     ymlfile.write('    n_is_absolute: false\n')
     ymlfile.write('    λ_is_vacuum: false\n')
-    if len(thermal_disp_coefficients) > 6:
-        ymlfile.write('    temperature: {}  °C\n'.format(thermal_disp_coefficients[6]))
-    if len(thermal_disp_coefficients) > 5 and \
-        (float(thermal_disp_coefficients[0]) or \
-            float(thermal_disp_coefficients[1]) or \
-            float(thermal_disp_coefficients[2]) or \
-            float(thermal_disp_coefficients[3]) or \
-            float(thermal_disp_coefficients[4]) or \
-            float(thermal_disp_coefficients[5])): 
+    if len(gd.thermal_disp_coefficients) > 6:
+        ymlfile.write('    temperature: {:.1f} °C\n'.format(float(gd.thermal_disp_coefficients[6])))
+    if len(gd.thermal_disp_coefficients) > 5 and \
+            (float(gd.thermal_disp_coefficients[0]) or \
+             float(gd.thermal_disp_coefficients[1]) or \
+             float(gd.thermal_disp_coefficients[2]) or \
+             float(gd.thermal_disp_coefficients[3]) or \
+             float(gd.thermal_disp_coefficients[4]) or \
+             float(gd.thermal_disp_coefficients[5])): 
         ymlfile.write('    coefficients_of_thermal_dispersion: {}\n'\
-            .format(' '.join([format(float(thermal_disp_coefficients[i])) \
+            .format(' '.join([format(float(gd.thermal_disp_coefficients[i])) \
                               for i in range(6) ]))) 
-    ymlfile.write('    n_d: {}\n'.format(nd))
-    ymlfile.write('    V_d: {}\n'.format(vd))
-    if float(glasscode) > 100000:
-        ymlfile.write('    glass_code: ' + glasscode + '\n')
+    ymlfile.write('    n_d: {}\n'.format(gd.nd))
+    ymlfile.write('    V_d: {}\n'.format(gd.vd))
+    if float(gd.glasscode) > 100000:
+        ymlfile.write('    glass_code: {}\n'.format(gd.glasscode))
     
     status_name = {1:'standard', 2:'preferred', 3:'special', 4:'obsolete',
                    5:'melt'}
     for num, desc in status_name.items():
-        if int(float(status)) == num:
+        if int(float(gd.status)) == num:
              ymlfile.write('    glass_status: {}\n'.format(desc))
 
-    if meltfreq != 0:
-        ymlfile.write('    glass_melt_frequency: {}\n'.format(meltfreq))
-    if density != '-' and float(density):
-        ymlfile.write('    density: {} g/cm<sup>3</sup>\n'.format(density))
-    if cte1 != '-' and float(cte1): #-30...70 C
+    if gd.meltfreq != 0:
+        ymlfile.write('    glass_melt_frequency: {}\n'.format(gd.meltfreq))
+    if gd.density != '-' and float(gd.density):
+        ymlfile.write('    density: {} g/cm<sup>3</sup>\n'.format(float(gd.density)))
+    if gd.cte1 != '-' and float(gd.cte1): #-30...70 C
         ymlfile.write('    coefficient_of_thermal_expansion_1: {} K<sup>-1</sup>\n'\
-                      .format(round(float(cte1)*1.0e-6,15)))
-    if cte2 != '-' and float(cte2): #20...300 C
+                      .format(round(float(gd.cte1)*1.0e-6,15)))
+    if gd.cte2 != '-' and float(gd.cte2): #20...300 C
         ymlfile.write('    coefficient_of_thermal_expansion_2: {} K<sup>-1</sup>\n'.\
-                       format(round(float(cte2)*1.0e-6,15)))
-    if dpgf != '-' and float(dpgf):
-        ymlfile.write('    ΔP_gF: {}\n'.format(dpgf))
-    if CR != '-' and float(CR) != -1:
-        ymlfile.write('    climatic_resistance: {}\n'.format(CR))
-    if FR != '-' and float(FR) != -1:
-        ymlfile.write('    stain_resistance: {}\n'.format(FR))
-    if SR != '-' and float(SR) != -1:
-        ymlfile.write('    acid_resistance: {}\n'.format(float(SR)))
-    if AR != '-' and float(AR) != -1:
-        ymlfile.write('    alkali_resistance: {}\n'.format(AR))
-    if PR != '-' and float(PR) != -1:
-        ymlfile.write('    phosphate_resistance: {}\n'.format(PR))
+                       format(round(float(gd.cte2)*1.0e-6,15)))
+    if gd.dpgf != '-' and float(gd.dpgf):
+        ymlfile.write('    ΔP_gF: {}\n'.format(float(gd.dpgf)))
+    if gd.CR != '-' and float(gd.CR) != -1:
+        ymlfile.write('    climatic_resistance: {}\n'.format(float(gd.CR)))
+    if gd.FR != '-' and float(gd.FR) != -1:
+        ymlfile.write('    stain_resistance: {}\n'.format(float(gd.FR)))
+    if gd.SR != '-' and float(gd.SR) != -1:
+        ymlfile.write('    acid_resistance: {}\n'.format(float(gd.SR)))
+    if gd.AR != '-' and float(gd.AR) != -1:
+        ymlfile.write('    alkali_resistance: {}\n'.format(float(gd.AR)))
+    if gd.PR != '-' and float(gd.PR) != -1:
+        ymlfile.write('    phosphate_resistance: {}\n'.format(float(gd.PR)))
 
     ymlfile.close()
     
     print('ok')
 
- 
+def process(agf_file):
+    gd = GlassData()
+    with open(agf_file) as agf:
+        for line in agf:
+            data = [k.strip() for k in line.split()]
+            if not len(data):
+                continue
+            if data[0] == 'NM':
+                if gd.glass_count!=0:
+                    WriteYML(gd)
+                    #sys.exit(0)
+                gd = GlassData()
+                gd.glass_count +=1
+                gd.name = data[1]
+                
+                gd.formula = data[2]
+                gd.glasscode = data[3]
+                gd.nd = data[4]
+                gd.vd = data[5]
+                if len(data) >= 8: gd.status = data[7] 
+                if len(data) >= 9 and data.count('-') < 0: gd.meltfreq = data[8]
+                else: gd.meltfreq = 0
+                continue
+            if data[0] == 'LD':
+                gd.wlmin = data[1]
+                gd.wlmax = data[2]
+                continue
+            if data[0] == 'CD':
+                gd.disp_formula_coefficients = data[1:]
+                continue
+            if data[0] == 'TD':
+                gd.thermal_disp_coefficients = data[1:]
+                continue
+            if data[0] == 'ED':
+                gd.cte1 = data[1]
+                gd.cte2 = data[2]
+                gd.density = data[3]
+                gd.dpgf = data[4]
+                continue
+            if data[0] == 'OD':
+                #? = data[1]
+                if len(data)>2:
+                    gd.CR = data[2]
+                    if gd.CR == '3-4':
+                        gd.CR = '3.5'
+                    gd.FR = data[3]
+                    gd.SR = data[4]
+                    gd.AR = data[5]
+                    gd.PR = data[6]
+                continue
+            if data[0] == 'IT':
+                gd.wl.append(data[1])
+                gd.IT.append(data[2])
+                gd.thickness.append(data[3])
+                continue
+            if data[0] == 'GC':
+                gd.comments = data[1:]
 
+        if gd.glass_count!=0: WriteYML(gd)
 
 ### main program
+if __name__ == "__main__":
+    process(agffile)
     
-ClearGlassData()
-
-glass_count = 0 #glass count
-
-with open(agffile) as agf:
-    for line in agf:
-        data = line.split()
-        if not len(data):
-            continue
-        if data[0] == 'NM':
-            if glass_count!=0: WriteYML()
-            ClearGlassData()
-            glass_count +=1
-            name = data[1]
-            formula = data[2]
-            glasscode = data[3]
-            nd = data[4]
-            vd = data[5]
-            if len(data) >= 8: status = data[7] 
-            if len(data) >= 9 and data.count('-') < 0: meltfreq = data[8]
-            else: meltfreq = 0
-            continue
-        if data[0] == 'LD':
-            wlmin = data[1]
-            wlmax = data[2]
-            continue
-        if data[0] == 'CD':
-            data.remove('CD')
-            disp_formula_coefficients = data
-            continue
-        if data[0] == 'TD':
-            data.remove('TD')
-            thermal_disp_coefficients = data
-            continue
-        if data[0] == 'ED':
-            cte1 = data[1]
-            cte2 = data[2]
-            density = data[3]
-            dpgf = data[4]
-            continue
-        if data[0] == 'OD':
-            #? = data[1]
-            if len(data)>2:
-                CR = data[2]
-                if CR == '3-4':
-                    CR = '3.5'
-                FR = data[3]
-                SR = data[4]
-                AR = data[5]
-                PR = data[6]
-            continue
-        if data[0] == 'IT':
-            wl.append(data[1])
-            IT.append(data[2])
-            thickness.append(data[3])
-            continue
-        if data[0] == 'GC':
-            data.remove('GC')
-            comments = data
-if glass_count!=0:WriteYML()
-
-

--- a/agf2yml/agf2yml.py
+++ b/agf2yml/agf2yml.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# coding: utf-8
 ###########################################################################################
 #         THIS PROGRAM IS IN PUBLIC DOMAIN                                                #
 #         COPYRIGHT AND RELATED RIGHTS WAIVED VIA CC0 1.0                                 #
@@ -93,95 +95,77 @@ def WriteYML():
         ymlfile.write('  - type: formula 3 \n')
     if formula == "2":
         ymlfile.write('  - type: formula 2 \n')
-    ymlfile.write('    range: ' + format(float(wlmin)) + ' ' + format(float(wlmax)) + '\n')
+    ymlfile.write('    range: {} {}\n'.format(wlmin, wlmax))
     ymlfile.write('    coefficients:')
     if formula == "1" or formula == "13":
-        if float(disp_formula_coefficients[0]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[0])))
-        if float(disp_formula_coefficients[1]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[1])) + ' 2')
-        if float(disp_formula_coefficients[2]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[2])) + ' 4')
-        if float(disp_formula_coefficients[3]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[3])) + ' -2')
-        if float(disp_formula_coefficients[4]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[4])) + ' -4')
-        if float(disp_formula_coefficients[5]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[5])) + ' -6')
-        if float(disp_formula_coefficients[6]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[6])) + ' -8')
-        if float(disp_formula_coefficients[7]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[7])) + ' -10')
-        if float(disp_formula_coefficients[8]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[8])) + ' -12')
+        for i, k in zip(range(8), ['', 2, 4, -2, -6, -8, -10, -12]):
+            if float(disp_formula_coefficients[i]):
+                ymlfile.write(' {} {}'.format(disp_formula_coefficients[i], k))
     if formula == "2":
         ymlfile.write(' 0')
-        if len(disp_formula_coefficients)>1 and float(disp_formula_coefficients[0]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[0])) + ' ' + format(float(disp_formula_coefficients[1])))
-        if len(disp_formula_coefficients)>3 and  float(disp_formula_coefficients[2]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[2])) + ' ' + format(float(disp_formula_coefficients[3])))
-        if len(disp_formula_coefficients)>5 and  float(disp_formula_coefficients[4]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[4])) + ' ' + format(float(disp_formula_coefficients[5])))
-        if len(disp_formula_coefficients)>7 and  float(disp_formula_coefficients[6]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[6])) + ' ' + format(float(disp_formula_coefficients[7])))
-        if len(disp_formula_coefficients)>9 and  float(disp_formula_coefficients[8]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[8])) + ' ' + format(float(disp_formula_coefficients[9])))
-        if len(disp_formula_coefficients)>11 and  float(disp_formula_coefficients[10]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[10])) + ' ' + format(float(disp_formula_coefficients[11])))
-        if len(disp_formula_coefficients)>13 and  float(disp_formula_coefficients[12]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[12])) + ' ' + format(float(disp_formula_coefficients[13])))
-        if len(disp_formula_coefficients)>15 and  float(disp_formula_coefficients[14]):
-            ymlfile.write(' ' + format(float(disp_formula_coefficients[14])) + ' ' + format(float(disp_formula_coefficients[15])))
+        num_coeff = len(disp_formula_coefficients) 
+        for i in range(0, 16, 2):
+            if num_coeff > i+1 and float(disp_formula_coefficients[i]):
+                ymlfile.write(' {} {}'.format(disp_formula_coefficients[i],
+                                              disp_formula_coefficients[i+1]))
     ymlfile.write('\n')
     
     ymlfile.write('  - type: tabulated k\n')
     ymlfile.write('    data: |\n')  
     for i in range (0,len(wl)):
         if float(IT[i]) != 0:
-            k = -float(wl[i])/(4*math.pi)*math.log(float(IT[i]))/(float(thickness[i])*1000)
-            ymlfile.write('        ' + "%.3f"%(float(wl[i])) + ' ' + format(k, '.4E') + '\n')
+            k = -float(wl[i]) / (4*math.pi) * \
+                math.log(float(IT[i])) / (float(thickness[i])*1000)
+            ymlfile.write('        {:.3f} {:.4E}\n'.format(float(wl[i]), k))
     
     ymlfile.write('INFO:\n')
     ymlfile.write('    n_is_absolute: false\n')
     ymlfile.write('    λ_is_vacuum: false\n')
-    if len(thermal_disp_coefficients)>6:
-        ymlfile.write('    temperature: ' + format(float(thermal_disp_coefficients[6])) + ' °C\n')
-    if len(thermal_disp_coefficients)>5 and (float(thermal_disp_coefficients[0]) or float(thermal_disp_coefficients[1]) or float(thermal_disp_coefficients[2]) or float(thermal_disp_coefficients[3]) or float(thermal_disp_coefficients[4]) or float(thermal_disp_coefficients[5])): 
-        ymlfile.write('    coefficients_of_thermal_dispersion: ' + ' '.join([format(float(thermal_disp_coefficients[i])) for i in range(6) ]) + '\n') 
-    ymlfile.write('    n_d: ' + nd + '\n')
-    ymlfile.write('    V_d: ' + vd + '\n')
-    if float(glasscode)>100000:
+    if len(thermal_disp_coefficients) > 6:
+        ymlfile.write('    temperature: {}  °C\n'.format(thermal_disp_coefficients[6]))
+    if len(thermal_disp_coefficients) > 5 and \
+        (float(thermal_disp_coefficients[0]) or \
+            float(thermal_disp_coefficients[1]) or \
+            float(thermal_disp_coefficients[2]) or \
+            float(thermal_disp_coefficients[3]) or \
+            float(thermal_disp_coefficients[4]) or \
+            float(thermal_disp_coefficients[5])): 
+        ymlfile.write('    coefficients_of_thermal_dispersion: {}\n'\
+            .format(' '.join([format(float(thermal_disp_coefficients[i])) \
+                              for i in range(6) ]))) 
+    ymlfile.write('    n_d: {}\n'.format(nd))
+    ymlfile.write('    V_d: {}\n'.format(vd))
+    if float(glasscode) > 100000:
         ymlfile.write('    glass_code: ' + glasscode + '\n')
-    if float(status)==1:    
-        ymlfile.write('    glass_status: standard\n')
-    if float(status)==2:    
-        ymlfile.write('    glass_status: preferred\n')
-    if float(status)==3:    
-        ymlfile.write('    glass_status: special\n')
-    if float(status)==4:    
-        ymlfile.write('    glass_status: obsolete\n')
-    if float(status)==5:    
-        ymlfile.write('    glass_status: melt\n')
+    
+    status_name = {1:'standard', 2:'preferred', 3:'special', 4:'obsolete',
+                   5:'melt'}
+    for num, desc in status_name.items():
+        if int(float(status)) == num:
+             ymlfile.write('    glass_status: {}\n'.format(desc))
+
     if meltfreq != 0:
-        ymlfile.write('    glass_melt_frequency: ' + meltfreq + '\n')
+        ymlfile.write('    glass_melt_frequency: {}\n'.format(meltfreq))
     if density != '-' and float(density):
-        ymlfile.write('    density: ' + format(float(density)) + ' g/cm<sup>3</sup>\n')
+        ymlfile.write('    density: {} g/cm<sup>3</sup>\n'.format(density))
     if cte1 != '-' and float(cte1): #-30...70 C
-        ymlfile.write('    coefficient_of_thermal_expansion_1: ' + format(round(float(cte1)*1.0e-6,15)) + ' K<sup>-1</sup>\n')
+        ymlfile.write('    coefficient_of_thermal_expansion_1: {} K<sup>-1</sup>\n'\
+                      .format(round(float(cte1)*1.0e-6,15)))
     if cte2 != '-' and float(cte2): #20...300 C
-        ymlfile.write('    coefficient_of_thermal_expansion_2: ' + format(round(float(cte2)*1.0e-6,15)) + ' K<sup>-1</sup>\n')
+        ymlfile.write('    coefficient_of_thermal_expansion_2: {} K<sup>-1</sup>\n'.\
+                       format(round(float(cte2)*1.0e-6,15)))
     if dpgf != '-' and float(dpgf):
-        ymlfile.write('    ΔP_gF: ' + format(float(dpgf)) + '\n')
+        ymlfile.write('    ΔP_gF: {}\n'.format(dpgf))
     if CR != '-' and float(CR) != -1:
-        ymlfile.write('    climatic_resistance: ' + format(float(CR)) + '\n')
+        ymlfile.write('    climatic_resistance: {}\n'.format(CR))
     if FR != '-' and float(FR) != -1:
-        ymlfile.write('    stain_resistance: ' + format(float(FR)) + '\n')
+        ymlfile.write('    stain_resistance: {}\n'.format(FR))
     if SR != '-' and float(SR) != -1:
-        ymlfile.write('    acid_resistance: ' + format(float(SR)) + '\n')
+        ymlfile.write('    acid_resistance: {}\n'.format(float(SR)))
     if AR != '-' and float(AR) != -1:
-        ymlfile.write('    alkali_resistance: ' + format(float(AR)) + '\n')
+        ymlfile.write('    alkali_resistance: {}\n'.format(AR))
     if PR != '-' and float(PR) != -1:
-        ymlfile.write('    phosphate_resistance: ' + format(float(PR)) + '\n')
+        ymlfile.write('    phosphate_resistance: {}\n'.format(PR))
 
     ymlfile.close()
     


### PR DESCRIPTION
Hello,

I wanted to look at this parser and cleanup the code a bit, but turns out I also found a bug:
sometimes, there are trailing spaces after "OD -", which the parser considered different as just a dash, causing the data from the previous material to be copied to that one.
A similar problem occurs with a comment.
The concerned materials are the following:

P-LASF50 (line 2798) 
P-SF69 (line 2901) 
P-SK58 (line 2990)
P-LAF37 (line 2707)
P-LAF32 (line 4071) 

Therefore, the values removed below are in fact copies of data from other materials.

This pull request cleans the code and fixes this bug.

``` diff
--- output_ref/schott/N-LAF32.yml       2016-02-05 11:18:44.862061449 +0100
+++ output/schott/N-LAF32.yml   2016-02-05 15:37:15.442411344 +0100
@@ -3,7 +3,6 @@
 # copyright and related rights waived via CC0 1.0

 REFERENCES: "1) <a href=\"http://refractiveindex.info/download/data/2015/schott-optical-glass-collection-datasheets-july-2015-us.pdf\">SCHOTT optical glass data sheets 2015-07-22</a><br>2) <a href=\"http://refractiveindex.info/download/data/2015/schottzemax-20150722.agf\">SCHOTT Zemax catalog 2015-07-22</a>"
-COMMENTS: "was replaced by N-FK51A"
 DATA:
     range: 0.35 2.5
     coefficients:
--- output_ref/schott/P-LAF37.yml       2016-02-05 11:18:44.840061806 +0100
+++ output/schott/P-LAF37.yml   2016-02-05 15:37:15.425411598 +0100
@@ -44,8 +44,3 @@
     coefficient_of_thermal_expansion_1: 6.26e-06 K<sup>-1</sup>
     coefficient_of_thermal_expansion_2: 7.8e-06 K<sup>-1</sup>
     ΔP_gF: -0.008
-    climatic_resistance: 1.0
-    stain_resistance: 0.0
-    acid_resistance: 2.0
-    alkali_resistance: 1.2
-    phosphate_resistance: 2.2
--- output_ref/schott/P-LASF50.yml      2016-02-05 11:18:44.842061773 +0100
+++ output/schott/P-LASF50.yml  2016-02-05 15:37:15.426411583 +0100
@@ -45,8 +45,3 @@
     coefficient_of_thermal_expansion_1: 5.9e-06 K<sup>-1</sup>
     coefficient_of_thermal_expansion_2: 7.32e-06 K<sup>-1</sup>
     ΔP_gF: -0.0078
-    climatic_resistance: 1.0
-    stain_resistance: 1.0
-    acid_resistance: 51.4
-    alkali_resistance: 1.0
-    phosphate_resistance: 2.2
--- output_ref/schott/P-SF69.yml        2016-02-05 11:18:44.843061757 +0100
+++ output/schott/P-SF69.yml    2016-02-05 15:37:15.427411568 +0100
@@ -41,8 +41,3 @@
     coefficient_of_thermal_expansion_1: 8.99e-06 K<sup>-1</sup>
     coefficient_of_thermal_expansion_2: 1.113e-05 K<sup>-1</sup>
     ΔP_gF: 0.0104
-    climatic_resistance: 1.0
-    stain_resistance: 5.0
-    acid_resistance: 53.3
-    alkali_resistance: 2.3
-    phosphate_resistance: 2.3
--- output_ref/schott/P-SK58A.yml       2016-02-05 11:18:44.845061725 +0100
+++ output/schott/P-SK58A.yml   2016-02-05 15:37:15.429411538 +0100
@@ -46,8 +46,3 @@
     coefficient_of_thermal_expansion_1: 6.82e-06 K<sup>-1</sup>
     coefficient_of_thermal_expansion_2: 8.41e-06 K<sup>-1</sup>
     ΔP_gF: -0.0023
-    climatic_resistance: 4.0
-    stain_resistance: 3.0
-    acid_resistance: 52.3
-    alkali_resistance: 2.0
-    phosphate_resistance: 3.0
--- output_ref/schott/SF66.yml  2016-02-05 11:18:44.864061416 +0100
+++ output/schott/SF66.yml      2016-02-05 15:37:15.443411329 +0100
@@ -30,8 +30,6 @@
 INFO:
     n_is_absolute: false
     λ_is_vacuum: false
-    temperature: 20.0 °C
-    coefficients_of_thermal_dispersion: 2.91e-06 1.69e-08 -3.77e-11 1.1e-06 1.07e-09 0.278
     n_d: 1.92286
     V_d: 20.88
     glass_code: 923209.603

```
